### PR TITLE
Ampersands aren't needed when the runner will stop on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ libzopfli:
 
 .PHONY: test
 test:
-	cargo test && ./test/run.sh
+	cargo test
+	./test/run.sh
 
 # Remove all libraries and binaries
 clean:

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 set -eu
-./zopfli test/data/* && mv test/data/*.gz test/results/ && git diff --exit-code test/results/
+
+./zopfli test/data/*
+mv test/data/*.gz test/results/
+git diff --exit-code test/results/


### PR DESCRIPTION
Makefiles stop on the first failure, and `set -e` causes Bash to do the
same thing.
