### PR TITLE
Exclude test files from the crate package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/carols10cents/zopfli"
 repository = "https://github.com/carols10cents/zopfli"
 readme = "README.md"
 categories = ["compression"]
+exclude = ["test/*"]
 
 [dependencies]
 crc = "1.2"


### PR DESCRIPTION
This decreases `*.crate` file (the one that cargo uses to build this crate) size from 479KiB to 36KiB.