### PR TITLE
Add streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
+name = "iter-read"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
+
+[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,5 +48,6 @@ dependencies = [
  "adler32",
  "byteorder",
  "crc",
+ "iter-read",
  "typed-arena",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crc = "2"
 adler32 = "1"
 byteorder = "1"
 typed-arena = "2"
+iter-read = "0.3.0"
 
 [profile.release]
 debug = true

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -14,7 +14,6 @@ use crate::symbols::{
 use crate::tree::lengths_to_symbols;
 use crate::util::{ZOPFLI_MASTER_BLOCK_SIZE, ZOPFLI_NUM_D, ZOPFLI_NUM_LL, ZOPFLI_WINDOW_SIZE};
 use crate::Options;
-use iter::IsFinalIterator;
 
 /// Compresses according to the deflate specification and append the compressed
 /// result to the output.

--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -1,5 +1,7 @@
+use std::io::{self, Read, Write};
+
 use byteorder::{LittleEndian, WriteBytesExt};
-use std::io::{self, Write};
+use iter_read::IterRead;
 
 use crate::deflate::{deflate, BlockType};
 use crate::Options;
@@ -17,15 +19,44 @@ static HEADER: &'static [u8] = &[
 ];
 
 /// Compresses the data according to the gzip specification, RFC 1952.
-pub fn gzip_compress<W>(options: &Options, in_data: &[u8], mut out: W) -> io::Result<()>
+pub fn gzip_compress<R, W>(options: &Options, in_data: R, insize: u64, mut out: W) -> io::Result<()>
 where
+    R: Read,
     W: Write,
 {
+    let mut crc_digest = CRC_IEEE.digest();
+    let mut read_error_kind = None;
+
+    let in_data = IterRead::new(
+        in_data
+            .bytes()
+            .filter_map(|byte_result| {
+                read_error_kind = byte_result.as_ref().map_or_else(
+                    |error| Some(error.kind()),
+                    |byte| {
+                        crc_digest.update(&[*byte]);
+                        None
+                    },
+                );
+
+                byte_result.ok()
+            })
+            .fuse(),
+    );
+
     out.by_ref().write_all(HEADER)?;
 
-    deflate(options, BlockType::Dynamic, in_data, out.by_ref())?;
+    deflate(options, BlockType::Dynamic, in_data, insize, out.by_ref())?;
+
+    // in_data is fused and stops reading bytes after the first error, so
+    // this if is evaluated as soon as an error occurs. The deflate function
+    // has received EOF at this point, so the last block has been written.
+    if let Some(error_kind) = read_error_kind {
+        return Err(error_kind.into());
+    }
 
     out.by_ref()
-        .write_u32::<LittleEndian>(CRC_IEEE.checksum(in_data))?;
-    out.write_u32::<LittleEndian>(in_data.len() as u32)
+        .write_u32::<LittleEndian>(crc_digest.finalize())?;
+
+    out.write_u32::<LittleEndian>(insize as u32)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,4 +37,5 @@ pub const ZOPFLI_MAX_CHAIN_HITS: usize = 8192;
 /// The whole compression algorithm, including the smarter block splitting, will
 /// be executed independently on each huge block.
 /// Dividing into huge blocks hurts compression, but not much relative to the size.
+/// This must be equal or greater than `ZOPFLI_WINDOW_SIZE`.
 pub const ZOPFLI_MASTER_BLOCK_SIZE: usize = 1000000;


### PR DESCRIPTION
These changes add streaming support to the crate, so entire files no longer have to be copied to main memory before being compressed. This streaming support is safer and easier to use than memmapping the file, a operation that is not entirely OS-agnostic and requires detailed analysis of how other processes may interact with the memmapped file to guarantee stability and safety. The crate now accepts any Read trait implementation for input data, which provides lots of flexibility.

Compression should be unaffected, as the input data is still read in blocks of ZOPFLI_MASTER_BLOCK_SIZE like before, and a sliding window of the last ZOPFLI_WINDOW_SIZE bytes read is kept to initialize the dictionary for each master block. To test that the changes work okay, I ran the test/run.sh script, which compressed the test files with no issues. I got the original idea for this improvement from https://github.com/google/zopfli/issues/14#issuecomment-77830531.

Although I tried to follow the style of the code that already exists and not introduce too much modern Rust features, MSRV is now bumped to 1.41. Also, the public interface exposed by this crate changed in a backwards-incompatible manner, but the crate major version is still 0, and semantic versioning conventions tell that public APIs in major version 0 are unstable, so I don't think this should be a problem.

Resolves #18.